### PR TITLE
feat: 添加函数代理限流功能

### DIFF
--- a/cmd/gateway.go
+++ b/cmd/gateway.go
@@ -44,7 +44,6 @@ func init() {
 }
 
 func runInitConfig(cmd *cobra.Command, args []string) {
-	types.GetConfig()
 	fmt.Printf("已生成配置文件至：%s\n", types.DEFAULT_CONFIG_PATH)
 }
 
@@ -69,6 +68,10 @@ func runGateway(cmd *cobra.Command, args []string) error {
 	}
 
 	function := route.Group("/function")
+	if config.Gateway.EnableRateLimit {
+		function.Use(middleware.RateLimit(config.Gateway.RateLimit))
+	}
+
 	{
 		function.POST("/:name", proxyHandler)
 		function.POST("/:name/:params", proxyHandler)

--- a/pkg/middleware/rateLimit.go
+++ b/pkg/middleware/rateLimit.go
@@ -1,0 +1,24 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/miRemid/cqless/pkg/httputil"
+	"github.com/miRemid/cqless/pkg/types"
+	"github.com/rs/zerolog/log"
+	"golang.org/x/time/rate"
+)
+
+func RateLimit(rateConfig *types.RateLimitConfig) gin.HandlerFunc {
+	log.Info().Float64("rateLimit.limit", rateConfig.Limit).Int("rateLimit.Burst", rateConfig.Burst).Msg("已启动令牌桶功能")
+	limit := rate.NewLimiter(rate.Limit(rateConfig.Limit), rateConfig.Burst)
+	return func(ctx *gin.Context) {
+		if limit.Allow() {
+			ctx.Next()
+		} else {
+			log.Debug().Msg("过多请求，拒绝调用")
+			ctx.AbortWithStatusJSON(http.StatusTooManyRequests, httputil.Response{})
+		}
+	}
+}

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -69,6 +69,11 @@ func initConfig() {
 			Type:   "random",
 			Params: map[string]string{},
 		},
+		EnableRateLimit: false,
+		RateLimit: &RateLimitConfig{
+			Limit: 10,
+			Burst: 1000,
+		},
 	})
 	viper.AddConfigPath(DEFAULT_CONFIG_PATH)
 	if err := viper.SafeWriteConfig(); err != nil {
@@ -136,6 +141,14 @@ type GatewayConfig struct {
 	ReadTimeout  time.Duration   `yaml:"read_timeout" mapstructure:"read_timeout"`
 	WriteTimeout time.Duration   `yaml:"write_timeout" mapstructure:"write_timeout"`
 	Resolver     *ResolverConfig `yaml:"resolver" mapstructure:"resolver"`
+
+	EnableRateLimit bool             `yaml:"enable_rate_limit" mapstructure:"enable_rate_limit"`
+	RateLimit       *RateLimitConfig `yaml:"rate_limit" mapstructure:"rate_limit"`
+}
+
+type RateLimitConfig struct {
+	Limit float64 `yaml:"limit" mapstructure:"limit"`
+	Burst int     `yaml:"burst" mapstructure:"burst"`
 }
 
 type ResolverConfig struct {


### PR DESCRIPTION
防止过多请求代理到函数容器，使用官方限流器`time/rate`进行限流